### PR TITLE
Hotfix 0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Release Log
-# `v0.0.1`: this version add a git flow for clang format check.
-* `v0.0.0`: this is the initial commit. We finish `cmake` config, `googletest` config, add `github workflow`.
+* `v0.0.2`: this version substitutes the `#` with `*`.
+* `v0.0.1`: this version adds a git flow for clang format check.
+* `v0.0.0`: this is the initial commit. We finish `cmake` config, `googletest` config, and add `github workflow`.
 
 # matrix-calculation-accelarator
 Matrix calculation implemented by C++ with multi thread


### PR DESCRIPTION
This substitutes the '#' before 'v0.0.1' of README.md with '*'.