### PR TITLE
Fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Release Log
+* `v0.0.3`: this version substitutes `multi thread` with `multi-thread`.
 * `v0.0.2`: this version substitutes the `#` with `*`.
 * `v0.0.1`: this version adds a git flow for clang format check.
 * `v0.0.0`: this is the initial commit. We finish `cmake` config, `googletest` config, and add `github workflow`.
 
 # matrix-calculation-accelarator
-Matrix calculation implemented by C++ with multi thread
+Matrix calculation implemented by C++ with multi-thread


### PR DESCRIPTION
Bump version up to `v0.0.3`. Substitute `multi thread` with `multi-thread` in `README.md`.