### PR TITLE
Fix git action failed on Windows when building shared library

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -60,7 +60,6 @@ jobs:
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-        -Dmca_BUILD_SHARE_LIB=off
         -S ${{ github.workspace }}
 
     - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,13 @@ else()
     add_library(mca STATIC ${mca_SOURCE})
 endif()
 
+find_package(Threads REQUIRED)
+target_link_libraries(mca PUBLIC Threads::Threads)
+# when built as a sub directory, epxort mca_LINK_LIB
+if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    set(mca_LINK_LIB ${CMAKE_THREAD_LIBS_INIT} PARENT_SCOPE)
+endif()
+
 target_include_directories(mca PUBLIC ${PROJECT_SOURCE_DIR}/src/include)
 
 find_program(CLANG_TIDY_EXE NAMES clang-tidy)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 3.14)
 
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    project(unit_test)
+    message(FATAL_ERROR "You can not build this project as a main project")
+endif()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
 set(CMAKE_CXX_EXTENSIONS off)
@@ -29,7 +34,20 @@ target_link_libraries(
     GTest::gtest_main
     mca)
 
-gtest_discover_tests(${PROJECT_NAME}_unit_test)
+# In windows when using VS, this cannot find the share lib
+# so we just update the working directory
+# if your config type is different with ${CMAKE_BUILD_TYPE}
+# you may need copy the libraries manually
+# or update the environment PATH to find where the shared lib is
+# if you build a static lib, this can be ignored
+if (mca_BUILD_SHARE_LIB AND WIN32 AND (CMAKE_GENERATOR MATCHES "Visual Studio"))
+    gtest_discover_tests(
+        ${PROJECT_NAME}_unit_test
+        WORKING_DIRECTORY
+        ${CMAKE_BINARY_DIR}/${LIBRARY_OUTPUT_PATH}/${CMAKE_BUILD_TYPE})
+else()
+    gtest_discover_tests(${PROJECT_NAME}_unit_test)
+endif()
 
 find_program(CLANG_TIDY_EXE NAMES clang-tidy)
 if (CLANG_TIDY_EXE)


### PR DESCRIPTION
GTest working directory has been changed to `build/lib`.

See #22.