### PR TITLE
Features for matrix class

### DIFF
--- a/src/include/matrix.h
+++ b/src/include/matrix.h
@@ -105,7 +105,8 @@ public:
     Shape getShape() const;
 
     // Reshape the matrix
-    // NOTE: this is only valid, when the new shape has the same elements with the old one
+    // NOTE: this is only valid, when the new shape has the same number of elements with the old
+    //       one
     void reshape(const Shape &shape);
 
     // Make all the elements of the matrix be a new value

--- a/src/include/matrix.h
+++ b/src/include/matrix.h
@@ -111,11 +111,11 @@ public:
     // Make all the elements of the matrix be a new value
     void fill(const ELEMENT_TYPE &value);
 
-    // Calcualte number ^ (*this), and store the result in output
+    // Calculate number ^ (*this), and store the result in output
     // If the output is nullptr, (*this) will be changed
     // NOTE: (*this) must have the same shape with output
-    //       If O and ELEMENT_TYPE are not same, all the elements will first be casted to
-    //       std::common_type<O, ELEMENT_TYPE>, after calculation they will be casted into O
+    //       If O and ELEMENT_TYPE are not same, all the elements will first be cast to
+    //       std::common_type<O, ELEMENT_TYPE>, after calculation they will be cast into O
     //       by using static_cast
     // for example: a = [[1, 2, 3],
     //                   [2, 3, 4]]
@@ -128,11 +128,11 @@ public:
     template <class Number, class O>
     void numberPow(Number &&number, const Matrix<O> &output = nullptr);
 
-    // Calcualte (*this) ^ number, and store the result in output
+    // Calculate (*this) ^ number, and store the result in output
     // If the output is nullptr, (*this) will be changed
     // NOTE: (*this) must have the same shape with output
-    //       If O and ELEMENT_TYPE are not same, all the elements will first be casted to
-    //       std::common_type<O, ELEMENT_TYPE>, after calculation they will be casted into O
+    //       If O and ELEMENT_TYPE are not same, all the elements will first be cast to
+    //       std::common_type<O, ELEMENT_TYPE>, after calculation they will be cast into O
     //       by using static_cast
     // for example: a = [[1, 2, 3],
     //                   [2, 3, 4]]
@@ -145,14 +145,14 @@ public:
     template <class Number, class O>
     void powNumber(Number &&number, const Matrix<O> &output = nullptr);
 
-    // Calcualte (*this) ^ exponet, and store the result in output
+    // Calculate (*this) ^ exponent, and store the result in output
     // This is different with powNumber or numberPow
-    // This will calculate the matrix exponention
+    // This will calculate the matrix exponentiation
     // This is only valid when (*this) is a square matrix
     // NOTE: (*this) must be a square matrix
     //       (*this) must have the same shape with output
-    //       If O and ELEMENT_TYPE are not same, all the elements will first be casted to
-    //       std::common_type<O, ELEMENT_TYPE>, after calculation they will be casted into O
+    //       If O and ELEMENT_TYPE are not same, all the elements will first be cast to
+    //       std::common_type<O, ELEMENT_TYPE>, after calculation they will be cast into O
     //       by using static_cast
     // for example: a = [[1, 2],
     //                   [2, 3]]
@@ -164,9 +164,9 @@ public:
 
     // Transpose (*this), and store the result in output
     // If the output is nullptr, (*this) will be changed
-    // NOTE: output must have the same shape with the current matrix after tranpositon
-    //       If O and ELEMENT_TYPE are not same, all the elements will first be casted to
-    //       std::common_type<O, ELEMENT_TYPE>, after calculation they will be casted into O
+    // NOTE: output must have the same shape with the current matrix after transposition
+    //       If O and ELEMENT_TYPE are not same, all the elements will first be cast to
+    //       std::common_type<O, ELEMENT_TYPE>, after calculation they will be cast into O
     //       by using static_cast
     // for example: a = [[1, 2, 3],
     //                   [2, 3, 4]]
@@ -180,6 +180,12 @@ public:
     //                  [3, 4]]
     template <class O>
     void transpose(Matrix<O> &output = nullptr);
+
+    // Check if the matrix is symmetric with multi-thread
+    bool symmetric();
+
+    // Check if the matrix is antisymmetric with multi-thread
+    bool antisymmetric();
 
 private:
     std::unique_ptr<ELEMENT_TYPE[]> data;
@@ -385,6 +391,17 @@ private:
                                       const size_t &sx,
                                       const size_t &sy,
                                       const Shape &shape);
+
+    template <class T>
+    friend bool symmetricSingleThread(const Matrix<T> &a,
+                                      const size_t &sx,
+                                      const size_t rows,
+                                      const double &eps);
+    template <class T>
+    friend bool antisymmetricSingleThread(const Matrix<T> &a,
+                                          const size_t &sx,
+                                          const size_t rows,
+                                          const double &eps);
 };
 
 inline Shape::Shape(size_t rows, size_t columns) : rows(rows), columns(columns) {}

--- a/src/include/mca.h
+++ b/src/include/mca.h
@@ -7,54 +7,57 @@ namespace mca {
 
 // the eps will be used when comparing matrices whose elements are floating numbers
 extern double eps;
+
 // Check if matrix a and matrix b are equal using multi-thread
-// NOTE: a's shape must be same with b'shape
-//       before comparison the elements will be converted to std::common_type<T1, T2>
+// return false when a's shape is not same with b's shape
+// NOTE: before comparison the elements will be converted to std::common_type<T1, T2>
 //       if they are floating number, the eps will be used to compare
 //       the default value of eps is 1e-100
 template <class T1, class T2>
 bool operator==(const Matrix<T1> &a, const Matrix<T2> &b);
 
 // Check if matrix a and matrix b are not equal using multi-thread
-// NOTE: a's shape must be same with b'shape
-//       before comparison the elements will be converted to std::common_type<T1, T2>
+// return true when a's shape is not same with b's shape
+// NOTE: before comparison the elements will be converted to std::common_type<T1, T2>
 //       if they are floating number, the eps will be used to compare
 //       the default value of eps is 1e-100
 template <class T1, class T2>
 bool operator!=(const Matrix<T1> &a, const Matrix<T2> &b);
 
 // Check if all the elements of a are less than b's using multi-thread
-// NOTE: a's shape must be same with b'shape
-//       before comparison the elements will be converted to std::common_type<T1, T2>
+// return false when a's shape is not same with b's shape
+// NOTE: before comparison the elements will be converted to std::common_type<T1, T2>
 //       if they are floating number, the eps will be used to compare
 //       the default value of eps is 1e-100
 template <class T1, class T2>
 bool operator<(const Matrix<T1> &a, const Matrix<T2> &b);
 
 // Check if all the elements of a are less or equal than b's using multi-thread
-// NOTE: a's shape must be same with b'shape
-//       before comparison the elements will be converted to std::common_type<T1, T2>
+// return false when a's shape is not same with b's shape
+// NOTE: before comparison the elements will be converted to std::common_type<T1, T2>
 //       if they are floating number, the eps will be used to compare
 //       the default value of eps is 1e-100
 template <class T1, class T2>
 bool operator<=(const Matrix<T1> &a, const Matrix<T2> &b);
 
 // Check if all the elements of a are greater than b's using multi-thread
-// NOTE: a's shape must be same with b'shape
-//       before comparison the elements will be converted to std::common_type<T1, T2>
+// return false when a's shape is not same with b's shape
+// NOTE: before comparison the elements will be converted to std::common_type<T1, T2>
 //       if they are floating number, the eps will be used to compare
 //       the default value of eps is 1e-100
 template <class T1, class T2>
 bool operator>(const Matrix<T1> &a, const Matrix<T2> &b);
 
 // Check if all the elements of a are greater or equal than b's using multi-thread
-// NOTE: a's shape must be same with b'shape
-//       the calculation will first calculate as std::common_type<T1, T2>
-//       then use static_cast<T1>
+// return false when a's shape is not same with b's shape
+// NOTE: before comparison the elements will be converted to std::common_type<T1, T2>
+//       if they are floating number, the eps will be used to compare
+//       the default value of eps is 1e-100
 template <class T1, class T2>
 bool operator>=(const Matrix<T1> &a, const Matrix<T2> &b);
 
 // Calculate a + b using multi-thread
+// return the result of a + b
 // NOTE: a's shape must be same with b'shape
 //       the calculation will first calculate as std::common_type<T1, T2>
 //       then use static_cast<T1>
@@ -62,6 +65,7 @@ template <class T1, class T2>
 Matrix<std::common_type_t<T1, T2>> operator+(const Matrix<T1> &a, const Matrix<T2> &b);
 
 // Calculate a - b using multi-thread
+// return the result of a - b
 // NOTE: a's shape must be same with b'shape
 //       the calculation will first calculate as std::common_type<T1, T2>
 //       then use static_cast<T1>
@@ -69,6 +73,7 @@ template <class T1, class T2>
 Matrix<std::common_type_t<T1, T2>> operator-(const Matrix<T1> &a, const Matrix<T2> &b);
 
 // Calculate a * b using multi-thread
+// return the result of a * b
 // NOTE: a's shape must be same with b'shape
 //       the calculation will first calculate as std::common_type<T1, T2>
 //       then use static_cast<T1>
@@ -76,6 +81,7 @@ template <class T1, class T2>
 Matrix<std::common_type_t<T1, T2>> operator*(const Matrix<T1> &a, const Matrix<T2> &b);
 
 // Calculate a + number using multi-thread
+// return the result of a + number
 // this is same with a + Matrix(a.getShape(), number)
 // for example: a = [[1, 2],
 //                   [3, 4]]
@@ -88,6 +94,7 @@ template <class T, class Number>
 Matrix<std::common_type_t<T, Number>> operator+(const Matrix<T> &a, const Number &number);
 
 // Calculate number + a using multi-thread
+// return the result of number + a
 // this is same with Matrix(a.getShape(), number) + a
 // for example: number = 1
 //              a = [[1, 2],
@@ -100,6 +107,7 @@ template <class Number, class T>
 Matrix<std::common_type_t<T, Number>> operator+(const Number &number, const Matrix<T> &a);
 
 // Calculate a - number using multi-thread
+// return the result of a - number
 // this is same with a - Matrix(a.getShape(), number)
 // for example: a = [[1, 2],
 //                   [3, 4]]
@@ -112,6 +120,7 @@ template <class T, class Number>
 Matrix<std::common_type_t<T, Number>> operator-(const Matrix<T> &a, const Number &number);
 
 // Calculate number - a using multi-thread
+// return the result of number - a
 // this is same with Matrix(a.getShape(), number) - a
 // for example: a = [[1, 2],
 //                   [3, 4]]
@@ -124,6 +133,7 @@ template <class Number, class T>
 Matrix<std::common_type_t<T, Number>> operator-(const Number &number, const Matrix<T> &a);
 
 // Calculate a * number using multi-thread
+// return the result of a * number
 // for example: a = [[1, 2],
 //                   [3, 4]]
 //              number = 1
@@ -135,6 +145,7 @@ template <class T, class Number>
 Matrix<std::common_type_t<T, Number>> operator*(const Matrix<T> &a, const Number &number);
 
 // Calculate number * a using multi-thread
+// return the result of number * a
 // for example: number = 1
 //              a = [[1, 2],
 //                   [3, 4]]
@@ -146,6 +157,7 @@ template <class Number, class T>
 Matrix<std::common_type_t<T, Number>> operator*(const Number &number, const Matrix<T> &a);
 
 // Calculate a / number using multi-thread
+// return the result of a / number
 // for example: a = [[1, 2],
 //                   [3, 4]]
 //              number = 1
@@ -157,6 +169,7 @@ template <class T, class Number>
 Matrix<std::common_type_t<T, Number>> operator/(const Matrix<T> &a, const Number &number);
 
 // Calculate number / a using multi-thread
+// return the result of number / a
 // this is same with Matrix(a.getShape(), number) / a
 // for example: a = [[1, 2],
 //                   [3, 4]]

--- a/src/include/mca.h
+++ b/src/include/mca.h
@@ -1,4 +1,340 @@
 #ifndef MCA_PRIVATE_H
 #define MCA_PRIVATE_H
 
+#include "matrix.h"
+
+namespace mca {
+
+// the eps will be used when comparing matrices whose elements are floating numbers
+extern double eps;
+// Check if matrix a and matrix b are equal using multi-thread
+// NOTE: a's shape must be same with b'shape
+//       before comparison the elements will be converted to std::common_type<T1, T2>
+//       if they are floating number, the eps will be used to compare
+//       the default value of eps is 1e-100
+template <class T1, class T2>
+bool operator==(const Matrix<T1> &a, const Matrix<T2> &b);
+
+// Check if matrix a and matrix b are not equal using multi-thread
+// NOTE: a's shape must be same with b'shape
+//       before comparison the elements will be converted to std::common_type<T1, T2>
+//       if they are floating number, the eps will be used to compare
+//       the default value of eps is 1e-100
+template <class T1, class T2>
+bool operator!=(const Matrix<T1> &a, const Matrix<T2> &b);
+
+// Check if all the elements of a are less than b's using multi-thread
+// NOTE: a's shape must be same with b'shape
+//       before comparison the elements will be converted to std::common_type<T1, T2>
+//       if they are floating number, the eps will be used to compare
+//       the default value of eps is 1e-100
+template <class T1, class T2>
+bool operator<(const Matrix<T1> &a, const Matrix<T2> &b);
+
+// Check if all the elements of a are less or equal than b's using multi-thread
+// NOTE: a's shape must be same with b'shape
+//       before comparison the elements will be converted to std::common_type<T1, T2>
+//       if they are floating number, the eps will be used to compare
+//       the default value of eps is 1e-100
+template <class T1, class T2>
+bool operator<=(const Matrix<T1> &a, const Matrix<T2> &b);
+
+// Check if all the elements of a are greater than b's using multi-thread
+// NOTE: a's shape must be same with b'shape
+//       before comparison the elements will be converted to std::common_type<T1, T2>
+//       if they are floating number, the eps will be used to compare
+//       the default value of eps is 1e-100
+template <class T1, class T2>
+bool operator>(const Matrix<T1> &a, const Matrix<T2> &b);
+
+// Check if all the elements of a are greater or equal than b's using multi-thread
+// NOTE: a's shape must be same with b'shape
+//       the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class T1, class T2>
+bool operator>=(const Matrix<T1> &a, const Matrix<T2> &b);
+
+// Calculate a + b using multi-thread
+// NOTE: a's shape must be same with b'shape
+//       the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class T1, class T2>
+Matrix<std::common_type_t<T1, T2>> operator+(const Matrix<T1> &a, const Matrix<T2> &b);
+
+// Calculate a - b using multi-thread
+// NOTE: a's shape must be same with b'shape
+//       the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class T1, class T2>
+Matrix<std::common_type_t<T1, T2>> operator-(const Matrix<T1> &a, const Matrix<T2> &b);
+
+// Calculate a * b using multi-thread
+// NOTE: a's shape must be same with b'shape
+//       the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class T1, class T2>
+Matrix<std::common_type_t<T1, T2>> operator*(const Matrix<T1> &a, const Matrix<T2> &b);
+
+// Calculate a + number using multi-thread
+// this is same with a + Matrix(a.getShape(), number)
+// for example: a = [[1, 2],
+//                   [3, 4]]
+//              number = 1
+//              return: [[1+1, 2+1],
+//                       [3+1, 4+1]]
+// NOTE: the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class T, class Number>
+Matrix<std::common_type_t<T, Number>> operator+(const Matrix<T> &a, const Number &number);
+
+// Calculate number + a using multi-thread
+// this is same with Matrix(a.getShape(), number) + a
+// for example: number = 1
+//              a = [[1, 2],
+//                   [3, 4]]
+//              return: [[1+1, 1+2],
+//                       [1+3, 1+4]]
+// NOTE: the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class Number, class T>
+Matrix<std::common_type_t<T, Number>> operator+(const Number &number, const Matrix<T> &a);
+
+// Calculate a - number using multi-thread
+// this is same with a - Matrix(a.getShape(), number)
+// for example: a = [[1, 2],
+//                   [3, 4]]
+//              number = 1
+//              return: [[1-1, 2-1],
+//                       [3-1, 4-1]]
+// NOTE: the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class T, class Number>
+Matrix<std::common_type_t<T, Number>> operator-(const Matrix<T> &a, const Number &number);
+
+// Calculate number - a using multi-thread
+// this is same with Matrix(a.getShape(), number) - a
+// for example: a = [[1, 2],
+//                   [3, 4]]
+//              number = 1
+//              return: [[1-1, 1-2],
+//                       [1-3, 1-4]]
+// NOTE: the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class Number, class T>
+Matrix<std::common_type_t<T, Number>> operator-(const Number &number, const Matrix<T> &a);
+
+// Calculate a * number using multi-thread
+// for example: a = [[1, 2],
+//                   [3, 4]]
+//              number = 1
+//              return: [[1*1, 2*1],
+//                       [3*1, 4*1]]
+// NOTE: the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class T, class Number>
+Matrix<std::common_type_t<T, Number>> operator*(const Matrix<T> &a, const Number &number);
+
+// Calculate number * a using multi-thread
+// for example: number = 1
+//              a = [[1, 2],
+//                   [3, 4]]
+//              return: [[1*1, 1*2],
+//                       [1*3, 1*4]]
+// NOTE: the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class Number, class T>
+Matrix<std::common_type_t<T, Number>> operator*(const Number &number, const Matrix<T> &a);
+
+// Calculate a / number using multi-thread
+// for example: a = [[1, 2],
+//                   [3, 4]]
+//              number = 1
+//              return: [[1/1, 2/1],
+//                       [3/1, 4/1]]
+// NOTE: the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class T, class Number>
+Matrix<std::common_type_t<T, Number>> operator/(const Matrix<T> &a, const Number &number);
+
+// Calculate number / a using multi-thread
+// this is same with Matrix(a.getShape(), number) / a
+// for example: a = [[1, 2],
+//                   [3, 4]]
+//              number = 1
+//              return: [[1/1, 1/2],
+//                       [1/3, 1/4]]
+// NOTE: the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class Number, class T>
+Matrix<std::common_type_t<T, Number>> operator/(const Number &number, const Matrix<T> &a);
+
+// Calculate a += b using multi-thread, the result will be stored in a
+// NOTE: a's shape must be same with b'shape
+//       the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class T1, class T2>
+void operator+=(Matrix<T1> &a, const Matrix<T2> &b);
+
+// Calculate a -= b using multi-thread, the result will be stored in a
+// NOTE: a's shape must be same with b'shape
+//       the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class T1, class T2>
+void operator-=(Matrix<T1> &a, const Matrix<T2> &b);
+
+// Calculate a *= b using multi-thread, the result will be stored in a
+// NOTE: a's shape must be same with b'shape
+//       the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class T1, class T2>
+void operator*=(Matrix<T1> &a, const Matrix<T2> &b);
+
+// Calculate a /= b using multi-thread, the result will be stored in a
+// NOTE: a's shape must be same with b'shape
+//       the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class T1, class T2>
+void operator/=(Matrix<T1> &a, const Matrix<T2> &b);
+
+// Calculate a += number using multi-thread, the result will be stored in a
+// NOTE: the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class T, class Number>
+void operator+=(Matrix<T> &a, const Number &number);
+
+// Calculate number += a using multi-thread, the result will be stored in a
+// NOTE: the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class Number, class T>
+void operator+=(const Number &number, Matrix<T> &a);
+
+// Calculate a -= number using multi-thread, the result will be stored in a
+// NOTE: the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class T, class Number>
+void operator-=(Matrix<T> &a, const Number &number);
+
+// Calculate number -= a using multi-thread, the result will be stored in a
+// NOTE: the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class Number, class T>
+void operator-=(const Number &number, Matrix<T> &a);
+
+// Calculate a *= number using multi-thread, the result will be stored in a
+// NOTE: the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class T, class Number>
+void operator*=(Matrix<T> &a, const Number &number);
+
+// Calculate number *= a using multi-thread, the result will be stored in a
+// NOTE: the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class Number, class T>
+void operator*=(const Number &number, Matrix<T> &a);
+
+// Calculate a /= number using multi-thread, the result will be stored in a
+// NOTE: the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class T, class Number>
+void operator/=(Matrix<T> &a, const Number &number);
+
+// Calculate number /= a using multi-thread, the result will be stored in a
+// NOTE: the calculation will first calculate as std::common_type<T1, T2>
+//       then use static_cast<T1>
+template <class Number, class T>
+void operator/=(const Number &number, Matrix<T> &a);
+
+// Those below are the implementations
+// TODO
+template <class T1, class T2>
+bool operator==(const Matrix<T1> &a, const Matrix<T2> &b) {}
+// TODO
+template <class T1, class T2>
+bool operator!=(const Matrix<T1> &a, const Matrix<T2> &b) {}
+// TODO
+template <class T1, class T2>
+bool operator<(const Matrix<T1> &a, const Matrix<T2> &b) {}
+// TODO
+template <class T1, class T2>
+bool operator<=(const Matrix<T1> &a, const Matrix<T2> &b) {}
+// TODO
+template <class T1, class T2>
+bool operator>(const Matrix<T1> &a, const Matrix<T2> &b) {}
+// TODO
+template <class T1, class T2>
+bool operator>=(const Matrix<T1> &a, const Matrix<T2> &b) {}
+
+// TODO
+template <class T1, class T2>
+Matrix<std::common_type_t<T1, T2>> operator+(const Matrix<T1> &a, const Matrix<T2> &b) {}
+// TODO
+template <class T1, class T2>
+Matrix<std::common_type_t<T1, T2>> operator-(const Matrix<T1> &a, const Matrix<T2> &b) {}
+// TODO
+template <class T1, class T2>
+Matrix<std::common_type_t<T1, T2>> operator*(const Matrix<T1> &a, const Matrix<T2> &b) {}
+
+// TODO
+template <class T, class Number>
+Matrix<std::common_type_t<T, Number>> operator+(const Matrix<T> &a, const Number &number) {}
+// TODO
+template <class Number, class T>
+Matrix<std::common_type_t<T, Number>> operator+(const Number &number, const Matrix<T> &a) {}
+// TODO
+template <class T, class Number>
+Matrix<std::common_type_t<T, Number>> operator-(const Matrix<T> &a, const Number &number) {}
+// TODO
+template <class Number, class T>
+Matrix<std::common_type_t<T, Number>> operator-(const Number &number, const Matrix<T> &a) {}
+// TODO
+template <class T, class Number>
+Matrix<std::common_type_t<T, Number>> operator*(const Matrix<T> &a,
+                                                // TODO
+                                                const Number &number) {}
+template <class Number, class T>
+Matrix<std::common_type_t<T, Number>> operator*(const Number &number, const Matrix<T> &a) {}
+// TODO
+template <class T, class Number>
+Matrix<std::common_type_t<T, Number>> operator/(const Matrix<T> &a, const Number &number) {}
+// TODO
+template <class Number, class T>
+Matrix<std::common_type_t<T, Number>> operator/(const Number &number, const Matrix<T> &a) {}
+
+// TODO
+template <class T1, class T2>
+void operator+=(Matrix<T1> &a, const Matrix<T2> &b) {}
+// TODO
+template <class T1, class T2>
+void operator-=(Matrix<T1> &a, const Matrix<T2> &b) {}
+// TODO
+template <class T1, class T2>
+void operator*=(Matrix<T1> &a, const Matrix<T2> &b) {}
+// TODO
+template <class T1, class T2>
+void operator/=(Matrix<T1> &a, const Matrix<T2> &b) {}
+// TODO
+template <class T, class Number>
+void operator+=(Matrix<T> &a, const Number &number) {}
+// TODO
+template <class Number, class T>
+void operator+=(const Number &number, Matrix<T> &a) {}
+// TODO
+template <class T, class Number>
+void operator-=(Matrix<T> &a, const Number &number) {}
+// TODO
+template <class Number, class T>
+void operator-=(const Number &number, Matrix<T> &a) {}
+// TODO
+template <class T, class Number>
+void operator*=(Matrix<T> &a, const Number &number) {}
+// TODO
+template <class Number, class T>
+void operator*=(const Number &number, Matrix<T> &a) {}
+// TODO
+template <class T, class Number>
+void operator/=(Matrix<T> &a, const Number &number) {}
+// TODO
+template <class Number, class T>
+void operator/=(const Number &number, Matrix<T> &a) {}
+}  // namespace mca
 #endif

--- a/src/include/single_thread_matrix_calculation.h
+++ b/src/include/single_thread_matrix_calculation.h
@@ -14,21 +14,22 @@ namespace mca {
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output
+//       &a must not be equal with &output
 //       the matrix which will be caculated must in range
 // for example: number = 2,
 //              a = [[1, 2, 3],
 //                   [2, 3, 4]]
 //              sx = 0, sy = 1
 //              shape = {2, 2}
-//              output = [[1, 2^2, 2^3],
-//                        [2, 2^3, 2^4]]
+//              output = [[origin, 2^2, 2^3],
+//                        [origin, 2^3, 2^4]]
 template <class Number, class T, class O>
-void powSingleThread(Number &&number,
-                     const Matrix<T> &a,
-                     Matrix<O> &output,
-                     const size_t &sx,
-                     const size_t &sy,
-                     const Shape &shape);
+void numberPowSingleThread(Number &&number,
+                           const Matrix<T> &a,
+                           Matrix<O> &output,
+                           const size_t &sx,
+                           const size_t &sy,
+                           const Shape &shape);
 
 // Calcualte a ^ number, and store the result in output
 // This will only calculate the a^number[sx:sx+shape.rows][sy:sy+shape+shape.columns]
@@ -36,25 +37,27 @@ void powSingleThread(Number &&number,
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output
+//       &a must not be equal with &output
 //       the matrix which will be caculated must in range
 // for example: number = 2,
 //              a = [[1, 2, 3],
 //                   [2, 3, 4]]
 //              sx = 0, sy = 1
 //              shape = {2, 2}
-//              output = [[1, 2^2, 3^2],
-//                        [2, 3^2, 4^2]]
+//              output = [[origin, 2^2, 3^2],
+//                        [origin, 3^2, 4^2]]
 template <class T, class Number, class O>
-void powSingleThread(const Matrix<T> &a,
-                     Number &&number,
-                     Matrix<O> &output,
-                     const size_t &sx,
-                     const size_t &sy,
-                     const Shape &shape);
+void powNumberSingleThread(const Matrix<T> &a,
+                           Number &&number,
+                           Matrix<O> &output,
+                           const size_t &sx,
+                           const size_t &sy,
+                           const Shape &shape);
 
 // Check if the elements of the sub-matrix of a are all less than the sub-matrix of b's
 // This will only check the a[sx:sx+shape.rows][sy:sy+shape+shape.columns] with
 // b[sx:sx+shape.rows][sy:sy+shape+shape.columns]
+// NOTE: eps will be used when T1 or T2 is floating number
 template <class T1, class T2>
 bool lessSingleThread(const Matrix<T1> &a,
                       const Matrix<T2> &b,
@@ -66,6 +69,7 @@ bool lessSingleThread(const Matrix<T1> &a,
 // Check if the elements of the sub-matrix of a are all equal with the sub-matrix of b's
 // This will only check the a[sx:sx+shape.rows][sy:sy+shape+shape.columns] with
 // b[sx:sx+shape.rows][sy:sy+shape+shape.columns]
+// NOTE: eps will be used when T1 or T2 is floating number
 template <class T1, class T2>
 inline bool equalSingleThread(const Matrix<T1> &a,
                               const Matrix<T2> &b,
@@ -77,6 +81,7 @@ inline bool equalSingleThread(const Matrix<T1> &a,
 // Check if the elements of the sub-matrix of a are all less than or equal with the sub-matrix of
 // b's This will only check the a[sx:sx+shape.rows][sy:sy+shape+shape.columns] with
 // b[sx:sx+shape.rows][sy:sy+shape+shape.columns]
+// NOTE: eps will be used when T1 or T2 is floating number
 template <class T1, class T2>
 inline bool lessEqualSingleThread(const Matrix<T1> &a,
                                   const Matrix<T2> &b,
@@ -88,6 +93,7 @@ inline bool lessEqualSingleThread(const Matrix<T1> &a,
 // Check if the elements of the sub-matrix of a are all greater than the sub-matrix of b's
 // This will only check the a[sx:sx+shape.rows][sy:sy+shape+shape.columns] with
 // b[sx:sx+shape.rows][sy:sy+shape+shape.columns]
+// NOTE: eps will be used when T1 or T2 is floating number
 template <class T1, class T2>
 inline bool greaterSingleThread(const Matrix<T1> &a,
                                 const Matrix<T2> &b,
@@ -99,6 +105,7 @@ inline bool greaterSingleThread(const Matrix<T1> &a,
 // Check if the elements of the sub-matrix of a are all greater than or equal with the sub-matrix of
 // b's This will only check the a[sx:sx+shape.rows][sy:sy+shape+shape.columns] with
 // b[sx:sx+shape.rows][sy:sy+shape+shape.columns]
+// NOTE: eps will be used when T1 or T2 is floating number
 template <class T1, class T2>
 inline bool greaterEqualSingleThread(const Matrix<T1> &a,
                                      const Matrix<T2> &b,
@@ -110,6 +117,7 @@ inline bool greaterEqualSingleThread(const Matrix<T1> &a,
 // Check if any element of the sub-matrix of a is not equal with the sub-matrix of b's
 // This will only check the a[sx:sx+shape.rows][sy:sy+shape+shape.columns] with
 // b[sx:sx+shape.rows][sy:sy+shape+shape.columns]
+// NOTE: eps will be used when T1 or T2 is floating number
 template <class T1, class T2>
 bool notEqualSingleThread(const Matrix<T1> &a,
                           const Matrix<T2> &b,
@@ -124,6 +132,7 @@ bool notEqualSingleThread(const Matrix<T1> &a,
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output and b
+//       &a must not be equal with &output
 //       the matrix which will be caculated must in range
 // for example: a = [[-1, -2, -3],
 //                   [-1, -2, -3]]
@@ -147,6 +156,7 @@ void addSingleThread(const Matrix<T1> &a,
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output and b
+//       &a must not be equal with &output
 //       the matrix which will be caculated must in range
 // for example: a = [[-1, -2, -3],
 //                   [-1, -2, -3]]
@@ -157,12 +167,12 @@ void addSingleThread(const Matrix<T1> &a,
 //              output = [[origin, -2-2, -3-3],
 //                        [origin, -2-3, -3-4]]
 template <class T1, class T2, class O>
-void substractSingleThread(const Matrix<T1> &a,
-                           const Matrix<T2> &b,
-                           Matrix<O> &output,
-                           const size_t &sx,
-                           const size_t &sy,
-                           const Shape &shape);
+void subtractSingleThread(const Matrix<T1> &a,
+                          const Matrix<T2> &b,
+                          Matrix<O> &output,
+                          const size_t &sx,
+                          const size_t &sy,
+                          const Shape &shape);
 
 // Calcualte a * b, and store the result in output
 // This will only calculate the a*b[sx:sx+shape.rows][sy:sy+shape+shape.columns]
@@ -170,6 +180,7 @@ void substractSingleThread(const Matrix<T1> &a,
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output and b
+//       &a must not be equal with &output
 //       the matrix which will be caculated must in range
 template <class T1, class T2, class O>
 void multiplySingleThread(const Matrix<T1> &a,
@@ -185,14 +196,15 @@ void multiplySingleThread(const Matrix<T1> &a,
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output
+//       &a must not be equal with &output
 //       the matrix which will be caculated must in range
 // for example: number = 2,
 //              a = [[1, 2, 3],
 //                   [2, 3, 4]]
 //              sx = 0, sy = 1
 //              shape = {2, 2}
-//              output = [[1, 2+2, 2+3],
-//                        [2, 2+3, 2+4]]
+//              output = [[origin, 2+2, 2+3],
+//                        [origin, 2+3, 2+4]]
 template <class Number, class T, class O>
 void addSingleThread(const Number &number,
                      const Matrix<T> &a,
@@ -207,21 +219,22 @@ void addSingleThread(const Number &number,
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output
+//       &a must not be equal with &output
 //       the matrix which will be caculated must in range
 // for example: number = 2,
 //              a = [[1, 2, 3],
 //                   [2, 3, 4]]
 //              sx = 0, sy = 1
 //              shape = {2, 2}
-//              output = [[1, 2-2, 2-3],
-//                        [2, 2-3, 2-4]]
+//              output = [[origin, 2-2, 2-3],
+//                        [origin, 2-3, 2-4]]
 template <class Number, class T, class O>
-void substractSingleThread(const Number &number,
-                           const Matrix<T> &a,
-                           Matrix<O> &output,
-                           const size_t &sx,
-                           const size_t &sy,
-                           const Shape &shape);
+void subtractSingleThread(const Number &number,
+                          const Matrix<T> &a,
+                          Matrix<O> &output,
+                          const size_t &sx,
+                          const size_t &sy,
+                          const Shape &shape);
 
 // Calcualte a - number, and store the result in output
 // This will only calculate the a^number[sx:sx+shape.rows][sy:sy+shape+shape.columns]
@@ -229,21 +242,22 @@ void substractSingleThread(const Number &number,
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output
+//       &a must not be equal with &output
 //       the matrix which will be caculated must in range
 // for example: number = 2,
 //              a = [[1, 2, 3],
 //                   [2, 3, 4]]
 //              sx = 0, sy = 1
 //              shape = {2, 2}
-//              output = [[1, 2-2, 3-2],
-//                        [2, 3-2, 4-2]]
+//              output = [[origin, 2-2, 3-2],
+//                        [origin, 3-2, 4-2]]
 template <class T, class Number, class O>
-void substractSingleThread(const Matrix<T> &a,
-                           const Number &number,
-                           Matrix<O> &output,
-                           const size_t &sx,
-                           const size_t &sy,
-                           const Shape &shape);
+void subtractSingleThread(const Matrix<T> &a,
+                          const Number &number,
+                          Matrix<O> &output,
+                          const size_t &sx,
+                          const size_t &sy,
+                          const Shape &shape);
 
 // Calcualte number * a, and store the result in output
 // This will only calculate the number*a[sx:sx+shape.rows][sy:sy+shape+shape.columns]
@@ -251,14 +265,15 @@ void substractSingleThread(const Matrix<T> &a,
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output
+//       &a must not be equal with &output
 //       the matrix which will be caculated must in range
 // for example: number = 2,
 //              a = [[1, 2, 3],
 //                   [2, 3, 4]]
 //              sx = 0, sy = 1
 //              shape = {2, 2}
-//              output = [[1, 2*2, 2*3],
-//                        [2, 2*3, 2*4]]
+//              output = [[origin, 2*2, 2*3],
+//                        [origin, 2*3, 2*4]]
 template <class Number, class T, class O>
 void multiplySingleThread(const Number &number,
                           const Matrix<T> &a,
@@ -273,14 +288,15 @@ void multiplySingleThread(const Number &number,
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output
+//       &a must not be equal with &output
 //       the matrix which will be caculated must in range
 // for example: number = 2,
 //              a = [[1, 2, 3],
 //                   [2, 3, 4]]
 //              sx = 0, sy = 1
 //              shape = {2, 2}
-//              output = [[1, 2/2, 3/2],
-//                        [2, 3/2, 4/2]]
+//              output = [[origin, 2/2, 3/2],
+//                        [origin, 3/2, 4/2]]
 template <class T, class Number, class O>
 void divideSingleThread(const Matrix<T> &a,
                         const Number &number,
@@ -295,14 +311,15 @@ void divideSingleThread(const Matrix<T> &a,
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output
+//       &a must not be equal with &output
 //       the matrix which will be caculated must in range
 // for example: number = 2,
 //              a = [[1, 2, 3],
 //                   [2, 3, 4]]
 //              sx = 0, sy = 1
 //              shape = {2, 2}
-//              output = [[1, 2/2, 2/3],
-//                        [2, 2/3, 2/4]]
+//              output = [[origin, 2/2, 2/3],
+//                        [origin, 2/3, 2/4]]
 template <class Number, class T, class O>
 void divideSingleThread(const Number &number,
                         const Matrix<T> &a,
@@ -317,6 +334,7 @@ void divideSingleThread(const Number &number,
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output after tranposition
+//       &a must not be equal with &output
 //       the matrix which will be caculated must in range
 // for example: number = 2,
 //              a = [[1, 2, 3],
@@ -335,12 +353,13 @@ void transposeSingleThread(const Matrix<T> &a,
 
 // Those below are the implementations
 template <class Number, class T, class O>
-void powSingleThread(Number &&number,
-                     const Matrix<T> &a,
-                     Matrix<O> &output,
-                     const size_t &sx,
-                     const size_t &sy,
-                     const Shape &shape) {
+void numberPowSingleThread(Number &&number,
+                           const Matrix<T> &a,
+                           Matrix<O> &output,
+                           const size_t &sx,
+                           const size_t &sy,
+                           const Shape &shape) {
+    assert(&a != &output);
     assert(a.shape == output.shape);
     assert(sx + shape.rows <= output.shape.rows);
     assert(sy + shape.columns <= output.shape.columns);
@@ -354,12 +373,13 @@ void powSingleThread(Number &&number,
 }
 
 template <class T, class Number, class O>
-void powSingleThread(const Matrix<T> &a,
-                     Number &&number,
-                     Matrix<O> &output,
-                     const size_t &sx,
-                     const size_t &sy,
-                     const Shape &shape) {
+void powNumberSingleThread(const Matrix<T> &a,
+                           Number &&number,
+                           Matrix<O> &output,
+                           const size_t &sx,
+                           const size_t &sy,
+                           const Shape &shape) {
+    assert(&a != &output);
     assert(a.shape == output.shape);
     assert(sx + shape.rows <= output.shape.rows);
     assert(sy + shape.columns <= output.shape.columns);
@@ -542,6 +562,7 @@ void multiplySingleThread(const Number &number,
                           const size_t &sx,
                           const size_t &sy,
                           const Shape &shape) {
+    assert(&a != &output);
     assert(a.shape == output.shape);
     assert(sx + shape.rows <= output.shape.rows);
     assert(sy + shape.columns <= output.shape.columns);
@@ -561,6 +582,7 @@ void addSingleThread(const Matrix<T1> &a,
                      const size_t &sx,
                      const size_t &sy,
                      const Shape &shape) {
+    assert(&a != &output);
     assert(a.shape == b.shape);
     assert(a.shape == output.shape);
     assert(sx + shape.rows <= output.shape.rows);
@@ -575,13 +597,13 @@ void addSingleThread(const Matrix<T1> &a,
 }
 
 template <class T1, class T2, class O>
-void substractSingleThread(const Matrix<T1> &a,
-                           const Matrix<T2> &b,
-                           Matrix<O> &output,
-                           const size_t &sx,
-                           const size_t &sy,
-                           const Shape &shape) {
-    assert(a.shape == b.shape);
+void subtractSingleThread(const Matrix<T1> &a,
+                          const Matrix<T2> &b,
+                          Matrix<O> &output,
+                          const size_t &sx,
+                          const size_t &sy,
+                          const Shape &shape) {
+    assert(&a != &output);
     assert(a.shape == b.shape);
     assert(sx + shape.rows <= a.shape.rows);
     assert(sy + shape.columns <= a.shape.columns);
@@ -629,6 +651,7 @@ void addSingleThread(const Number &number,
                      const size_t &sx,
                      const size_t &sy,
                      const Shape &shape) {
+    assert(&a != &output);
     assert(a.shape == output.shape);
     assert(sx + shape.rows <= output.shape.rows);
     assert(sy + shape.columns <= output.shape.columns);
@@ -642,12 +665,13 @@ void addSingleThread(const Number &number,
 }
 
 template <class Number, class T, class O>
-void substractSingleThread(const Number &number,
-                           const Matrix<T> &a,
-                           Matrix<O> &output,
-                           const size_t &sx,
-                           const size_t &sy,
-                           const Shape &shape) {
+void subtractSingleThread(const Number &number,
+                          const Matrix<T> &a,
+                          Matrix<O> &output,
+                          const size_t &sx,
+                          const size_t &sy,
+                          const Shape &shape) {
+    assert(&a != &output);
     assert(a.shape == output.shape);
     assert(sx + shape.rows <= output.shape.rows);
     assert(sy + shape.columns <= output.shape.columns);
@@ -660,12 +684,13 @@ void substractSingleThread(const Number &number,
     }
 }
 template <class T, class Number, class O>
-void substractSingleThread(const Matrix<T> &a,
-                           const Number &number,
-                           Matrix<O> &output,
-                           const size_t &sx,
-                           const size_t &sy,
-                           const Shape &shape) {
+void subtractSingleThread(const Matrix<T> &a,
+                          const Number &number,
+                          Matrix<O> &output,
+                          const size_t &sx,
+                          const size_t &sy,
+                          const Shape &shape) {
+    assert(&a != &output);
     assert(a.shape == output.shape);
     assert(sx + shape.rows <= output.shape.rows);
     assert(sy + shape.columns <= output.shape.columns);
@@ -685,6 +710,7 @@ void divideSingleThread(const Matrix<T> &a,
                         const size_t &sx,
                         const size_t &sy,
                         const Shape &shape) {
+    assert(&a != &output);
     assert(a.shape == output.shape);
     assert(sx + shape.rows <= output.shape.rows);
     assert(sy + shape.columns <= output.shape.columns);
@@ -704,6 +730,7 @@ void divideSingleThread(const Number &number,
                         const size_t &sx,
                         const size_t &sy,
                         const Shape &shape) {
+    assert(&a != &output);
     assert(a.shape == output.shape);
     assert(sx + shape.rows <= output.shape.rows);
     assert(sy + shape.columns <= output.shape.columns);

--- a/src/include/single_thread_matrix_calculation.h
+++ b/src/include/single_thread_matrix_calculation.h
@@ -373,12 +373,12 @@ bool symmetricSingleThread(const Matrix<T> &a,
 // rows: the number of rows
 // NOTE: a must be a square matrix
 //       sx + rows must less or equal a.rows()
-// for example: a = [[1, 2, 3],
-//                   [2, 3, 4],
-//                   [3, 6, 5]]
-//              sx = 0
-//              rows = 1
-//              return: false
+// for example: a = [[1,  2, 3],
+//                   [2,  3, 4],
+//                   [3, -4, 5]]
+//              sx = 1
+//              rows = 2
+//              return: true
 template <class T>
 bool antisymmetricSingleThread(const Matrix<T> &a,
                                const size_t &sx,

--- a/src/include/single_thread_matrix_calculation.h
+++ b/src/include/single_thread_matrix_calculation.h
@@ -8,14 +8,14 @@
 
 namespace mca {
 
-// Calcualte number ^ a, and store the result in output
+// Calculate number ^ a, and store the result in output
 // This will only calculate the number^a[sx:sx+shape.rows][sy:sy+shape+shape.columns]
 // sx: start row
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output
 //       &a must not be equal with &output
-//       the matrix which will be caculated must in range
+//       the matrix which will be calculated must in range
 // for example: number = 2,
 //              a = [[1, 2, 3],
 //                   [2, 3, 4]]
@@ -31,14 +31,14 @@ void numberPowSingleThread(Number &&number,
                            const size_t &sy,
                            const Shape &shape);
 
-// Calcualte a ^ number, and store the result in output
+// Calculate a ^ number, and store the result in output
 // This will only calculate the a^number[sx:sx+shape.rows][sy:sy+shape+shape.columns]
 // sx: start row
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output
 //       &a must not be equal with &output
-//       the matrix which will be caculated must in range
+//       the matrix which will be calculated must in range
 // for example: number = 2,
 //              a = [[1, 2, 3],
 //                   [2, 3, 4]]
@@ -126,14 +126,14 @@ bool notEqualSingleThread(const Matrix<T1> &a,
                           const Shape &shape,
                           const double &eps = 1e-100);
 
-// Calcualte a + b, and store the result in output
+// Calculate a + b, and store the result in output
 // This will only calculate the a+b[sx:sx+shape.rows][sy:sy+shape+shape.columns]
 // sx: start row
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output and b
 //       &a must not be equal with &output
-//       the matrix which will be caculated must in range
+//       the matrix which will be calculated must in range
 // for example: a = [[-1, -2, -3],
 //                   [-1, -2, -3]]
 //              b = [[1, 2, 3],
@@ -150,14 +150,14 @@ void addSingleThread(const Matrix<T1> &a,
                      const size_t &sy,
                      const Shape &shape);
 
-// Calcualte a - b, and store the result in output
+// Calculate a - b, and store the result in output
 // This will only calculate the a-b[sx:sx+shape.rows][sy:sy+shape+shape.columns]
 // sx: start row
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output and b
 //       &a must not be equal with &output
-//       the matrix which will be caculated must in range
+//       the matrix which will be calculated must in range
 // for example: a = [[-1, -2, -3],
 //                   [-1, -2, -3]]
 //              b = [[1, 2, 3],
@@ -174,14 +174,14 @@ void subtractSingleThread(const Matrix<T1> &a,
                           const size_t &sy,
                           const Shape &shape);
 
-// Calcualte a * b, and store the result in output
+// Calculate a * b, and store the result in output
 // This will only calculate the a*b[sx:sx+shape.rows][sy:sy+shape+shape.columns]
 // sx: start row
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output and b
 //       &a must not be equal with &output
-//       the matrix which will be caculated must in range
+//       the matrix which will be calculated must in range
 template <class T1, class T2, class O>
 void multiplySingleThread(const Matrix<T1> &a,
                           const Matrix<T2> &b,
@@ -190,14 +190,14 @@ void multiplySingleThread(const Matrix<T1> &a,
                           const size_t &sy,
                           const Shape &shape);
 
-// Calcualte number + a, and store the result in output
+// Calculate number + a, and store the result in output
 // This will only calculate the number+a[sx:sx+shape.rows][sy:sy+shape+shape.columns]
 // sx: start row
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output
 //       &a must not be equal with &output
-//       the matrix which will be caculated must in range
+//       the matrix which will be calculated must in range
 // for example: number = 2,
 //              a = [[1, 2, 3],
 //                   [2, 3, 4]]
@@ -213,14 +213,14 @@ void addSingleThread(const Number &number,
                      const size_t &sy,
                      const Shape &shape);
 
-// Calcualte number - a, and store the result in output
+// Calculate number - a, and store the result in output
 // This will only calculate the number+a[sx:sx+shape.rows][sy:sy+shape+shape.columns]
 // sx: start row
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output
 //       &a must not be equal with &output
-//       the matrix which will be caculated must in range
+//       the matrix which will be calculated must in range
 // for example: number = 2,
 //              a = [[1, 2, 3],
 //                   [2, 3, 4]]
@@ -236,14 +236,14 @@ void subtractSingleThread(const Number &number,
                           const size_t &sy,
                           const Shape &shape);
 
-// Calcualte a - number, and store the result in output
+// Calculate a - number, and store the result in output
 // This will only calculate the a^number[sx:sx+shape.rows][sy:sy+shape+shape.columns]
 // sx: start row
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output
 //       &a must not be equal with &output
-//       the matrix which will be caculated must in range
+//       the matrix which will be calculated must in range
 // for example: number = 2,
 //              a = [[1, 2, 3],
 //                   [2, 3, 4]]
@@ -259,14 +259,14 @@ void subtractSingleThread(const Matrix<T> &a,
                           const size_t &sy,
                           const Shape &shape);
 
-// Calcualte number * a, and store the result in output
+// Calculate number * a, and store the result in output
 // This will only calculate the number*a[sx:sx+shape.rows][sy:sy+shape+shape.columns]
 // sx: start row
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output
 //       &a must not be equal with &output
-//       the matrix which will be caculated must in range
+//       the matrix which will be calculated must in range
 // for example: number = 2,
 //              a = [[1, 2, 3],
 //                   [2, 3, 4]]
@@ -282,14 +282,14 @@ void multiplySingleThread(const Number &number,
                           const size_t &sy,
                           const Shape &shape);
 
-// Calcualte a / number, and store the result in output
+// Calculate a / number, and store the result in output
 // This will only calculate the a^number[sx:sx+shape.rows][sy:sy+shape+shape.columns]
 // sx: start row
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output
 //       &a must not be equal with &output
-//       the matrix which will be caculated must in range
+//       the matrix which will be calculated must in range
 // for example: number = 2,
 //              a = [[1, 2, 3],
 //                   [2, 3, 4]]
@@ -305,14 +305,14 @@ void divideSingleThread(const Matrix<T> &a,
                         const size_t &sy,
                         const Shape &shape);
 
-// Calcualte number / a, and store the result in output
+// Calculate number / a, and store the result in output
 // This will only calculate the number+a[sx:sx+shape.rows][sy:sy+shape+shape.columns]
 // sx: start row
 // sy: start column
 // shape: the shape of matrix will be calculated
 // NOTE: a must have the same shape with output
 //       &a must not be equal with &output
-//       the matrix which will be caculated must in range
+//       the matrix which will be calculated must in range
 // for example: number = 2,
 //              a = [[1, 2, 3],
 //                   [2, 3, 4]]
@@ -329,13 +329,13 @@ void divideSingleThread(const Number &number,
                         const Shape &shape);
 
 // Transpose a matrix, and store the result in output
-// This will only get the tansposed a[sx:sx+shape.rows][sy:sy+shape+shape.columns]
+// This will only get the transposed a[sx:sx+shape.rows][sy:sy+shape+shape.columns]
 // sx: start row
 // sy: start column
 // shape: the shape of matrix will be calculated
-// NOTE: a must have the same shape with output after tranposition
+// NOTE: a must have the same shape with output after transposition
 //       &a must not be equal with &output
-//       the matrix which will be caculated must in range
+//       the matrix which will be calculated must in range
 // for example: number = 2,
 //              a = [[1, 2, 3],
 //                   [2, 3, 4]]
@@ -350,6 +350,40 @@ void transposeSingleThread(const Matrix<T> &a,
                            const size_t &sx,
                            const size_t &sy,
                            const Shape &shape);
+
+// Check whether or not rows of matrix are symmetric
+// sx: start row
+// rows: the number of rows
+// NOTE: a must be a square matrix
+//       sx + rows must less or equal a.rows()
+// for example: a = [[1, 2, 3],
+//                   [2, 3, 4],
+//                   [3, 6, 5]]
+//              sx = 0
+//              rows = 1
+//              return: true
+template <class T>
+bool symmetricSingleThread(const Matrix<T> &a,
+                           const size_t &sx,
+                           const size_t rows,
+                           const double &eps = 1e-100);
+
+// Check whether or not rows of matrix are antisymmetric
+// sx: start row
+// rows: the number of rows
+// NOTE: a must be a square matrix
+//       sx + rows must less or equal a.rows()
+// for example: a = [[1, 2, 3],
+//                   [2, 3, 4],
+//                   [3, 6, 5]]
+//              sx = 0
+//              rows = 1
+//              return: false
+template <class T>
+bool antisymmetricSingleThread(const Matrix<T> &a,
+                               const size_t &sx,
+                               const size_t rows,
+                               const double &eps = 1e-100);
 
 // Those below are the implementations
 template <class Number, class T, class O>
@@ -756,6 +790,44 @@ void transposeSingleThread(const Matrix<T> &a,
     for (size_t i = sx; i < sx + shape.rows; i++) {
         for (size_t j = sy; j < sy + shape.columns; j++) { output.get(i, j) = a.get(j, i); }
     }
+}
+
+template <class T>
+bool symmetricSingleThread(const Matrix<T> &a,
+                           const size_t &sx,
+                           const size_t rows,
+                           const double &eps) {
+    assert(a.rows() == a.columns());
+    assert(sx + rows <= a.rows());
+    for (size_t i = sx; i < sx + rows; i++) {
+        for (size_t j = i + 1; j < a.columns(); j++) {
+            if (std::is_floating_point_v<T> && fabs(a.get(i, j) - a.get(j, i)) > eps) {
+                return false;
+            } else if (!std::is_floating_point_v<T> && a.get(i, j) != a.get(j, i)) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+template <class T>
+bool antisymmetricSingleThread(const Matrix<T> &a,
+                               const size_t &sx,
+                               const size_t rows,
+                               const double &eps) {
+    assert(a.rows() == a.columns());
+    assert(sx + rows <= a.rows());
+    for (size_t i = sx; i < sx + rows; i++) {
+        for (size_t j = i + 1; j < a.columns(); j++) {
+            if (std::is_floating_point_v<T> && fabs(a.get(i, j) + a.get(j, i)) > eps) {
+                return false;
+            } else if (!std::is_floating_point_v<T> && a.get(i, j) != -a.get(j, i)) {
+                return false;
+            }
+        }
+    }
+    return true;
 }
 }  // namespace mca
 #endif

--- a/src/include/thread_pool.h
+++ b/src/include/thread_pool.h
@@ -40,7 +40,7 @@ public:
     // this will return a std::future
     // you can use the object's get() to get the return value of your task
     template <class Function, class... Args>
-    auto addTask(Function &&func, Args &&... args)
+    auto addTask(Function &&func, Args &&...args)
         -> std::future<std::invoke_result_t<Function, Args...>>;
 
     // clear the taskQueue
@@ -67,7 +67,7 @@ private:
 };
 
 template <class Function, class... Args>
-auto ThreadPool::addTask(Function &&func, Args &&... args)
+auto ThreadPool::addTask(Function &&func, Args &&...args)
     -> std::future<std::invoke_result_t<Function, Args...>> {
     using ReturnType = std::invoke_result_t<Function, Args...>;
     auto taskPtr     = std::make_shared<std::packaged_task<ReturnType()>>(

--- a/src/mca.cpp
+++ b/src/mca.cpp
@@ -1,3 +1,5 @@
 #include "mca.h"
 
-#include "single_thread_matrix_calculation.h"
+namespace mca {
+double eps = 1e-100;
+}

--- a/test/src/single_thread_matrix_calculation_test.cpp
+++ b/test/src/single_thread_matrix_calculation_test.cpp
@@ -3,7 +3,6 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
-#include <iostream>
 
 #include "matrix.h"
 

--- a/test/src/single_thread_matrix_calculation_test.cpp
+++ b/test/src/single_thread_matrix_calculation_test.cpp
@@ -11,15 +11,17 @@ namespace mca {
 namespace test {
 class TestSinglThreadCalculation : public testing::Test {
 protected:
-    Matrix<> one, negOne, output, a, b, c, d;
+    Matrix<> one, negOne, output, a, b, c, d, sym, antisym;
 
     void SetUp() override {
-        one    = Matrix<>({3, 3}, 1);
-        negOne = Matrix<>({3, 3}, -1);
-        a      = Matrix<>({{0, 0, 0}, {1, 1, 1}, {2, 2, 2}});
-        b      = Matrix<>({{1, 0, 0}, {0, 1, 0}, {0, 0, 1}});
-        c      = Matrix<>({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}});
-        d      = Matrix<>({{0, 0, 0}, {1, 1, 1}, {2, 2, 2}});
+        one     = Matrix<>({3, 3}, 1);
+        negOne  = Matrix<>({3, 3}, -1);
+        a       = Matrix<>({{0, 0, 0}, {1, 1, 1}, {2, 2, 2}});
+        b       = Matrix<>({{1, 0, 0}, {0, 1, 0}, {0, 0, 1}});
+        c       = Matrix<>({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}});
+        d       = Matrix<>({{0, 0, 0}, {1, 1, 1}, {2, 2, 2}});
+        sym     = Matrix<>({{1, 2. / 3, 3. / 5}, {4. / 6, 3, 8. / 6}, {1.5 / 2.5, 4. / 3, 5}});
+        antisym = Matrix<>({{1, -2. / 3, -3. / 5}, {4. / 6, 3, -8. / 6}, {1.5 / 2.5, 4. / 3, 5}});
     }
 
     void TearDown() override {}
@@ -193,5 +195,26 @@ TEST_F(TestSinglThreadCalculation, transposeSubMatrix) {
     Matrix<> result({{-1, -1, -1}, {-1, 5, 8}, {-1, 6, 9}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, 0, output.getShape()));
 }
+
+TEST_F(TestSinglThreadCalculation, symmetricWholeMatrix) {
+    ASSERT_TRUE(symmetricSingleThread(sym, 0, 3));
+    ASSERT_FALSE(symmetricSingleThread(antisym, 0, 3));
+}
+
+TEST_F(TestSinglThreadCalculation, symmetricSubMatrix) {
+    ASSERT_TRUE(symmetricSingleThread(sym, 1, 2));
+    ASSERT_FALSE(symmetricSingleThread(antisym, 1, 2));
+}
+
+TEST_F(TestSinglThreadCalculation, antisymmetricWholeMatrix) {
+    ASSERT_TRUE(antisymmetricSingleThread(antisym, 0, 3));
+    ASSERT_FALSE(antisymmetricSingleThread(sym, 0, 3));
+}
+
+TEST_F(TestSinglThreadCalculation, antisymmetricSubMatrix) {
+    ASSERT_TRUE(antisymmetricSingleThread(antisym, 0, 1));
+    ASSERT_FALSE(antisymmetricSingleThread(sym, 0, 1));
+}
+
 }  // namespace test
 }  // namespace mca

--- a/test/src/single_thread_matrix_calculation_test.cpp
+++ b/test/src/single_thread_matrix_calculation_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <iostream>
 
 #include "matrix.h"
 
@@ -24,30 +25,33 @@ protected:
     void TearDown() override {}
 };
 
-TEST_F(TestSinglThreadCalculation, powWholeMatrix) {
+TEST_F(TestSinglThreadCalculation, powNumberWholeMatrix) {
     output = Matrix<>({3, 3}, 0);
-    powSingleThread(2, a, output, 0, 0, a.getShape());
-    for (size_t i = 0; i < output.rows(); i++) {
-        for (size_t j = 0; j < output.columns(); j++) {
-            ASSERT_DOUBLE_EQ(std::pow(2.0, i), output.get(i, j));
-        }
-    }
-    powSingleThread(a, 2, output, 0, 0, a.getShape());
-    for (size_t i = 0; i < output.rows(); i++) {
-        for (size_t j = 0; j < output.columns(); j++) {
-            ASSERT_DOUBLE_EQ(std::pow(i, 2.0), output.get(i, j));
-        }
-    }
+    powNumberSingleThread(a, 2, output, 0, 0, a.getShape());
+    Matrix<> result = Matrix<>({{0, 0, 0}, {1, 1, 1}, {4, 4, 4}});
+    std::cout << output.rows() << output.columns() << std::endl;
+    std::cout << result.rows() << result.columns() << std::endl;
+    ASSERT_TRUE(equalSingleThread(output, result, 0, 0, output.getShape()));
 }
 
-TEST_F(TestSinglThreadCalculation, powSubMatrix) {
+TEST_F(TestSinglThreadCalculation, powNumberSubMatrix) {
     output = Matrix<>({3, 3}, -1);
-    powSingleThread(2, c, output, 0, 1, {2, 2});
-    Matrix<> result({{-1, 4, 8}, {-1, 32, 64}, {-1, -1, -1}});
+    powNumberSingleThread(c, 2, output, 0, 1, {2, 2});
+    Matrix<> result = Matrix<>({{-1, 4, 9}, {-1, 25, 36}, {-1, -1, -1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, 0, output.getShape()));
+}
+
+TEST_F(TestSinglThreadCalculation, numberPowWholeMatrix) {
+    output = Matrix<>({3, 3}, 0);
+    numberPowSingleThread(2, a, output, 0, 0, a.getShape());
+    Matrix<> result = Matrix<>({{1, 1, 1}, {2, 2, 2}, {4, 4, 4}});
+    ASSERT_TRUE(equalSingleThread(output, result, 0, 0, output.getShape()));
+}
+
+TEST_F(TestSinglThreadCalculation, numberPowSubMatrix) {
     output = Matrix<>({3, 3}, -1);
-    powSingleThread(c, 2, output, 0, 1, {2, 2});
-    result = Matrix({{-1, 4, 9}, {-1, 25, 36}, {-1, -1, -1}});
+    numberPowSingleThread(2, c, output, 0, 1, {2, 2});
+    Matrix<> result({{-1, 4, 8}, {-1, 32, 64}, {-1, -1, -1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, 0, output.getShape()));
 }
 
@@ -65,6 +69,7 @@ TEST_F(TestSinglThreadCalculation, equalWholeMatrix) {
     ASSERT_TRUE(equalSingleThread(a, d, 0, 0, a.getShape()));
     ASSERT_FALSE(equalSingleThread(a, b, 0, 0, a.getShape()));
 }
+
 TEST_F(TestSinglThreadCalculation, equalSubMatrix) {
     ASSERT_TRUE(equalSingleThread(a, d, 1, 0, {2, 2}));
     ASSERT_FALSE(equalSingleThread(a, b, 1, 0, {2, 2}));
@@ -133,22 +138,22 @@ TEST_F(TestSinglThreadCalculation, addSubMatrix) {
 
 TEST_F(TestSinglThreadCalculation, sustractWholeMatrix) {
     output = Matrix<>({3, 3}, 0);
-    substractSingleThread(a, b, output, 0, 0, a.getShape());
+    subtractSingleThread(a, b, output, 0, 0, a.getShape());
     Matrix<> result({{-1, 0, 0}, {1, 0, 1}, {2, 2, 1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, 0, output.getShape()));
 
-    substractSingleThread(b, a, output, 0, 0, b.getShape());
+    subtractSingleThread(b, a, output, 0, 0, b.getShape());
     result = Matrix<>({{1, 0, 0}, {-1, 0, -1}, {-2, -2, -1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, 0, output.getShape()));
 }
 
 TEST_F(TestSinglThreadCalculation, sustractSubMatrix) {
     output = Matrix<>({3, 3}, -1);
-    substractSingleThread(a, b, output, 1, 1, {2, 2});
+    subtractSingleThread(a, b, output, 1, 1, {2, 2});
     Matrix<> result({{-1, -1, -1}, {-1, 0, 1}, {-1, 2, 1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, 0, output.getShape()));
 
-    substractSingleThread(b, a, output, 1, 1, {2, 2});
+    subtractSingleThread(b, a, output, 1, 1, {2, 2});
     result = Matrix<>({{-1, -1, -1}, {-1, 0, -1}, {-1, -2, -1}});
     ASSERT_TRUE(equalSingleThread(output, result, 0, 0, output.getShape()));
 }


### PR DESCRIPTION
Those declarations are added:
* Constructor to construct a identity matrix.
* Constructor to construct with a `std::initializer_list`.
* Constructor to construct a diagnonal matrix.
* Assaignment from `std::initializer_list`.
* A method to calculate matrix exponentiation.

Because we now use `pow` to calculate matrix exponentiation, the old `pow`s are renamed with `powNumber` and `numberPow`. The single thread version functions are renamed with `powNumberSinglthread` and `numPowSingleThread`. By the way, we found `*pow*` suitable for member functions, so we adjust them as member functions.

We can use move to reduce copy, so now add a rule that all the `output` in `*SingleThread` should not be at the same address with input parameters.

Update some comments (the comments are for developers): make them more readable.

We add comments (the comments are for developers and users) for the methods in Matrix class.

Besides, we move all the definitions of Matrix and Shape out of the classes.

Add the implementations of symmetricSingleThread() and antisymmetricSingleThread(). Finish the unit tests for the two methods.

See #34 .